### PR TITLE
Fix TypeScript definitions for framework integrations (v1.1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jods",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A minimal, reactive JSON state layer for Node.js and the browser",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/preact.ts
+++ b/src/preact.ts
@@ -1,0 +1,68 @@
+/**
+ * Preact framework integration for Jods
+ *
+ * Provides hooks for using Jods stores in Preact applications
+ * @packageDocumentation
+ */
+
+// Re-export core functionality
+export { store, computed, isComputed, json, diff } from "./core";
+export { onUpdate } from "./core/life-cycle/on-update";
+export type { Subscriber, Unsubscribe, ComputedValue } from "./types";
+export type { Store, StoreState } from "./core";
+export { persist, clearPersisted, getPersisted, isPersisted } from "./persist";
+export type {
+  PersistOptions,
+  PersistOperation,
+  PersistStorage,
+} from "./persist/types";
+
+// Preact-specific hooks
+/**
+ * Preact hook to subscribe to a Jods store
+ *
+ * Provides state from the store with basic properties and computed values
+ *
+ * @template T - Type of the store state
+ * @param store - Jods store to subscribe to
+ * @returns Current state with computed properties available
+ *
+ * @remarks
+ * IMPORTANT: Computed properties are returned as functions that must be
+ * called to access their values. For example:
+ *
+ * ```tsx
+ * const state = useJods(userStore);
+ *
+ * // Access a regular property
+ * const name = state.name;
+ *
+ * // Access a computed property (must be called)
+ * const fullName = typeof state.fullName === 'function'
+ *   ? state.fullName()
+ *   : state.fullName;
+ * ```
+ */
+export { useJods } from "./frameworks/preact/useJodsPreact";
+
+/**
+ * Preact hook for persisting Jods stores
+ *
+ * Handles loading and saving store data to the provided storage
+ *
+ * @template T - Type of the store state
+ * @param storage - Storage adapter (like localStorage)
+ * @param storeOrStores - Single store or array of stores to persist
+ * @param options - Optional persist configuration
+ * @returns Object with loading state, error state, and clear function
+ *
+ * @example
+ * ```tsx
+ * // Persist a single store
+ * const { isLoading, error, clear } = usePersist(localStorage, todoStore);
+ *
+ * // Persist multiple stores
+ * const { isLoading, error, clear } = usePersist(localStorage, [userStore, todoStore]);
+ * ```
+ */
+export { usePersist } from "./frameworks/preact/usePersist";

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,0 +1,39 @@
+/**
+ * React integration for JODS
+ *
+ * This file is separated from the main package to avoid
+ * requiring React as a dependency for non-React users.
+ *
+ * @example
+ * ```jsx
+ * import { store } from 'jods';
+ * import { useJods } from 'jods/react';
+ *
+ * const userStore = store({ name: 'Burt Macklin' });
+ *
+ * function UserProfile() {
+ *   const user = useJods(userStore);
+ *   return <div>{user.name}</div>;
+ * }
+ * ```
+ */
+
+// Re-export core functionality
+export { store, computed, isComputed, json, diff } from "./core";
+export { onUpdate } from "./core/life-cycle/on-update";
+export type { Subscriber, Unsubscribe, ComputedValue } from "./types";
+export type { Store, StoreState } from "./core";
+export { persist, clearPersisted, getPersisted, isPersisted } from "./persist";
+export type {
+  PersistOptions,
+  PersistOperation,
+  PersistStorage,
+} from "./persist/types";
+
+// React-specific hooks
+export { useJods } from "./frameworks/react/useJods";
+export { usePersist } from "./frameworks/react/usePersist";
+
+// Export debugger component
+import { createDebugger } from "./frameworks/react/debugger";
+export { createDebugger };

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -1,0 +1,10 @@
+/**
+ * Remix framework integration for Jods
+ *
+ * Provides hooks and utilities for using Jods stores in Remix applications
+ * @packageDocumentation
+ */
+
+// Re-export everything from the Remix integration
+export * from "./frameworks/remix/index";
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,9 +12,9 @@ export default defineConfig({
     lib: {
       entry: {
         index: resolve(__dirname, "src/index.ts"),
-        react: resolve(__dirname, "src/frameworks/react/index.ts"),
-        preact: resolve(__dirname, "src/frameworks/preact/index.ts"),
-        remix: resolve(__dirname, "src/frameworks/remix/index.ts"),
+        react: resolve(__dirname, "src/react.ts"),
+        preact: resolve(__dirname, "src/preact.ts"),
+        remix: resolve(__dirname, "src/remix.ts"),
         zod: resolve(__dirname, "src/zod.ts"),
       },
       formats: ["es", "cjs"],
@@ -37,6 +37,10 @@ export default defineConfig({
       tsconfigPath: "./tsconfig.json",
       staticImport: true,
       insertTypesEntry: true,
+      pathsToAliases: true,
+      compilerOptions: {
+        declarationMap: false,
+      },
     }),
   ],
   test: {


### PR DESCRIPTION
- Fixed broken import paths in React/Preact/Remix type definitions
- Created dedicated entry point files (src/react.ts, src/preact.ts, src/remix.ts)
- Type paths now correctly resolve (./core instead of ../../../../core)
- Updated vite.config.ts to use new entry points
- Configured vite-plugin-dts with pathsToAliases option

This fixes the issue where TypeScript couldn't resolve imports from 'jods/react', 'jods/preact', etc.

# Description

Please include a summary of the changes and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## AI Optimization Checklist

- [ ] I've run `pnpm run ai:sync` to verify AI-optimized files are in sync
- [ ] I've generated AI-optimized versions for any new complex files
- [ ] I've reviewed all generated AI-optimized files for accuracy

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
